### PR TITLE
Fix syntax error in Transparency sync commit

### DIFF
--- a/src/multiplayer/packet.h
+++ b/src/multiplayer/packet.h
@@ -65,7 +65,7 @@ public:
 	static T Decode(std::string_view s);
 
 	template<>
-	int Decode(std::string_view s) {
+	int Decode<int>(std::string_view s) {
 		int r;
 		auto e = std::from_chars(s.data(), s.data() + s.size(), r);
 		//if (e.ec != std::errc())
@@ -74,7 +74,7 @@ public:
 	}
 
 	template<>
-	bool Decode(std::string_view s) {
+	bool Decode<bool>(std::string_view s) {
 		if (s == "1")
 			return true;
 		//if (s == "0")


### PR DESCRIPTION
Fixes a build error from the transparency commit, according to the testsuite's results. Doesn't fix the problem when it won't load on the website though, so it just fixes the build errors for now.