### PR TITLE
YNO: prevent use-after-free by removing to-be-deleted sprites from drawlist

### DIFF
--- a/src/drawable_list.h
+++ b/src/drawable_list.h
@@ -86,6 +86,9 @@ class DrawableList {
 		template <typename F>
 		void TakeFrom(DrawableList& other, F&& predicate) noexcept;
 
+		template <typename F>
+		void Retain(F&& predicate) noexcept;
+
 		/** @return true if the list is dirty and needs to be sorted */
 		bool IsDirty() const;
 
@@ -172,6 +175,28 @@ void DrawableList::TakeFrom(DrawableList& other, F&& cond) noexcept {
 	SetDirty();
 	if (olist.empty()) {
 		other.SetClean();
+	}
+}
+
+template <typename F>
+void DrawableList::Retain(F&& predicate) noexcept {
+	int shift = 0;
+	const size_t size = _list.size();
+
+	for (size_t i = 0; i < size; ++i) {
+		auto* draw = _list[i];
+		if (!predicate(draw)) {
+			++shift;
+		} else if (shift) {
+			_list[i - shift] = std::move(_list[i]);
+		}
+	}
+
+	if (shift) {
+		_list.resize(size - shift);
+		SetDirty();
+		if (_list.empty())
+			SetClean();
 	}
 }
 


### PR DESCRIPTION
Closes #60
Also merges in some commits from 0.8.1

Happens when the player is in a menu screen (or any scene != map), and the
client loses connection; on reconnect, the list of players and dc'd players
are cleared leaving the pointers in the map scene's drawlist dangling.