### PR TITLE
Send rrfl only if there's a repeating flash set

### DIFF
--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -738,7 +738,9 @@ void Game_Multiplayer::ApplyScreenTone() {
 
 void Game_Multiplayer::Update() {
 	if (session_active) {
-		if (last_flash_frame_index > -1 && frame_index > last_flash_frame_index) {
+		if (last_flash_frame_index > -1
+				&& last_frame_flash.get() != nullptr
+				&& frame_index > last_flash_frame_index) {
 			connection.SendPacketAsync<RemoveRepeatingFlashPacket>();
 			last_flash_frame_index = -1;
 			last_frame_flash.reset();


### PR DESCRIPTION
This patch prevents rrfl packets from being sent after non-repeating flash packets. I've noticed it's pretty common in areas that have flashes once every 2~3 frames.