### PR TITLE
Make other users' repeating flash intensity consistent with the player's

### DIFF
--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -819,6 +819,7 @@ void Game_Multiplayer::Update() {
 
 		bool check_chat_name_overlap = frame_index % (8 + ((players.size() >> 4) << 3)) == 0;
 
+		ApplyRepeatingFlashes();
 		for (auto& p : players) {
 			auto& q = p.second.mvq;
 			auto& ch = p.second.ch;

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -96,8 +96,6 @@ void Spriteset_Map::Update() {
 		character_sprite->SetTone(new_tone);
 	}
 
-	GMI().ApplyRepeatingFlashes();
-
 	panorama->SetOx(Game_Map::Parallax::GetX());
 	panorama->SetOy(Game_Map::Parallax::GetY());
 	panorama->SetTone(new_tone);


### PR DESCRIPTION
Looks like the flash is a little bit stronger when `Flash` is called after `Game_Character::Update` for the given other player. `Spriteset_Map::Update` runs after `Game_Multiplayer::Update` (which calls the individual `Update` methods of other players) so the call had to be moved to the latter.

| Current `master` | This patch |
| ---------------- | ---------- |
| ![rfl-before](https://github.com/user-attachments/assets/b0a0ce5c-1f41-42e5-af49-940be86cc681) | ![rfl-after](https://github.com/user-attachments/assets/aa862957-417b-48f9-850b-f6431bd21330) |